### PR TITLE
Fix typo

### DIFF
--- a/lib/src/csv_loader.dart
+++ b/lib/src/csv_loader.dart
@@ -8,7 +8,7 @@ import '_csv_processor.dart';
 ///
 /// Example:
 /// ```dart
-/// var csv = CsvLoader.withHeaders(myStream);`
+/// var csv = CsvLoader.withHeaders(myStream);
 /// await for (var row in csv.rows) {
 ///   // do something with the row
 /// }


### PR DESCRIPTION
I removed an unnecessary back quote in an example code in a comment.